### PR TITLE
Fixes/improvements

### DIFF
--- a/Starksoft.Aspen/GnuPG/GpgKey.cs
+++ b/Starksoft.Aspen/GnuPG/GpgKey.cs
@@ -149,6 +149,13 @@ namespace Starksoft.Aspen.GnuPG
 
             _userName = name.Match(uid).ToString().Trim();
             _userId = userId.Match(uid).ToString();
+            if (string.IsNullOrEmpty(_userName))
+            {
+                Regex rgx = new Regex(@"uid +");
+                _userName = rgx.Replace(uid, "");
+            }
+            Regex rgx2 = new Regex(@"\[.*\] ");
+            _userName = rgx2.Replace(_userName, "");
         }
 
     }

--- a/Starksoft.Aspen/GnuPG/GpgKeyCollection.cs
+++ b/Starksoft.Aspen/GnuPG/GpgKeyCollection.cs
@@ -66,27 +66,6 @@ namespace Starksoft.Aspen.GnuPG
             _raw = keys.ReadToEnd();
         }
 
-        //private void Fill(StreamReader data)
-        //{
-        //    string line = null;
-        //    line = data.ReadLine();
-        //    line = data.ReadLine();
-        //    do
-        //    {
-        //        string line1 = data.ReadLine();
-        //        string line2 = data.ReadLine();
-        //        string line3 = data.ReadLine();
-        //        while (!data.EndOfStream && !(line3.StartsWith("sub") || line3.StartsWith("ssb")))
-        //        {
-        //            line3 = data.ReadLine();
-        //        }
-        //        GnuPGKey key = new GnuPGKey(String.Format("{0}\r\n{1}\r\n{2}", line1, line2, line3));
-        //        _keyList.Add(key);
-        //        data.ReadLine();
-        //    }
-        //    while (!data.EndOfStream);
-        //}
-
         private void Fill(StreamReader data)
         {
             string text = "";
@@ -97,7 +76,7 @@ namespace Starksoft.Aspen.GnuPG
                 string line = data.ReadLine();
 
                 // skip lines we are not interested in
-                if (!line.StartsWith("pub") && !line.StartsWith("sec") && !line.StartsWith("uid"))
+                if (!line.StartsWith("pub") && !line.StartsWith("sec") && !line.StartsWith("uid") && !line.StartsWith("sub"))
                 {
                     // make sure this isn't the end of a key parsing operation
                     if (text.Length != 0)
@@ -107,7 +86,7 @@ namespace Starksoft.Aspen.GnuPG
                     }
                     continue;
                 }
-                text += line;
+                text += line + Environment.NewLine;
             }
         }
 


### PR DESCRIPTION
Fixes:
1) GPG_COMMON_INSTALLATION_PATH has to point to a file, not a folder
2) NPI on missing registry key
3) Error handling did not show actual message for failed cmd executions;
4) Key collection did not work because of 2 bugs (tested on the latest gpg2)

Enhancements:
1) Added path for 64-bit systems
2) Add ability to import new public key
3) Added ability to ignore errors – very useful for peeking into partial content (preview)
