### PR TITLE
Some servers send a different response

### DIFF
--- a/Starksoft.Aspen/Ftps/FtpsRequest.cs
+++ b/Starksoft.Aspen/Ftps/FtpsRequest.cs
@@ -509,7 +509,7 @@ namespace Starksoft.Aspen.Ftps
                 case FtpsCmd.Mfct:
                     return BuildResponseArray(FtpsResponseCode.FileStatus);
                 case FtpsCmd.Opts:
-                    return BuildResponseArray(FtpsResponseCode.CommandOkay);
+                    return BuildResponseArray(FtpsResponseCode.CommandOkay, FtpsResponseCode.CommandNotImplementedSuperfluousAtThisSite);
                 case FtpsCmd.Hash:
                     return BuildResponseArray(FtpsResponseCode.FileStatus);
                 case FtpsCmd.Clnt:


### PR DESCRIPTION
I'm trying to use FileZilla server, newer version, and its response to
OPTS UTF8ON is 202:

```
(000006)25/11/2015 17:23:36 - server (127.0.0.1)> OPTS UTF8 ON
(000006)25/11/2015 17:23:36 - server (127.0.0.1)> 202 UTF8 mode is
always enabled. No need to send this command.
```

So, the response to OPTS isn't always CommandOkay, but Superfluous too.

Cya.
