### PR TITLE
SignEncrypt missing --encrypt option

### DIFF
--- a/Starksoft.Aspen/GnuPG/Gpg.cs
+++ b/Starksoft.Aspen/GnuPG/Gpg.cs
@@ -614,6 +614,8 @@ namespace Starksoft.Aspen.GnuPG
                     // if a filename needs to be embedded in the encrypted blob, set it
                     if (!String.IsNullOrEmpty(_filename))
                         options.Append(String.Format(CultureInfo.InvariantCulture, "--set-filename \"{0}\" ", _filename));
+                        
+                    options.Append("--encrypt ");
 
                     // determine which type of signature to generate
                     switch (_outputSignatureType)


### PR DESCRIPTION
I believe the SignEncrypt action should also add the --encrypt option.