### PR TITLE
Issue with listing keys when specifying a home folder

### DIFF
--- a/Starksoft.Aspen/GnuPG/Gpg.cs
+++ b/Starksoft.Aspen/GnuPG/Gpg.cs
@@ -436,7 +436,7 @@ namespace Starksoft.Aspen.GnuPG
         /// <returns>Collection of GnuPGKey objects.</returns>
         public GpgKeyCollection GetSecretKeys()
         {
-            return new GpgKeyCollection(ExecuteGpgNoIO("--list-secret-keys"));
+            return new GpgKeyCollection(ExecuteGpgNoIO("--list-secret-keys "));
         }
 
         /// <summary>
@@ -445,7 +445,7 @@ namespace Starksoft.Aspen.GnuPG
         /// <returns>Collection of GnuPGKey objects.</returns>
         public GpgKeyCollection GetKeys()
         {
-            return new GpgKeyCollection(ExecuteGpgNoIO("--list-keys"));
+            return new GpgKeyCollection(ExecuteGpgNoIO("--list-keys "));
         }
 
         /// <summary>


### PR DESCRIPTION
Missing spaces after the options list-keys and list-secret-keys, which is required if you want to specify the home folder where the keys are stored.