### PR TITLE
Fix parsing of filenames with semicolons. Remove unnecessary CRLF aft…

### DIFF
--- a/Starksoft.Aspen.Test/TestFtpMlsx.cs
+++ b/Starksoft.Aspen.Test/TestFtpMlsx.cs
@@ -39,18 +39,21 @@ namespace Starksoft.Aspen.Tests
         /// </summary>
         /// <param name="line">MLSx line text to parse and load.</param>
         [CLSCompliant(false)]
-        [TestCase("Type=file;Size=1830;Modify=19940916055648;Perm=r; hatch.c")]
-        [TestCase("modify=20120822211414;perm=adfr;size=2101;type=file;unique=16UF3F5;UNIX.group=49440;UNIX.mode=0744;UNIX.owner=49440; iphone_settings_icon.jpg")]
-        [TestCase("modify=20030225143801;perm=adfr;size=503;type=file;unique=12U24470006;UNIX.group=0;UNIX.mode=0644;UNIX.owner=0; welcome.msg")]
-        [TestCase("type=dir;modify=20120825130005; /Test")]
-        [TestCase("create=20120825130005;lang=en;media-type=TEXT;charset=UTF-8;modify=20030225143801;perm=acdeflmprw;size=3243243332343503;type=file;unique=12U24470006;UNIX.group=100;UNIX.mode=0644;UNIX.owner=1000; wel come.msg")]
-        [TestCase("create=20120825130005;lang=fr;media-type=TEXT;charset=UTF-7;modify=20030225143801;perm=acdeflmprw;size=3243243332343503;type=pdir;unique=12U24470006;UNIX.group=100;UNIX.mode=0644;UNIX.owner=1000; wel come.msg")]
-        [TestCase("create=20120825130005;lang=sp;media-type=TEXT;charset=UTF-8;modify=20030225143801;perm=acdeflmprw;size=3243243332343503;type=cdir;unique=12U24470006;UNIX.group=100;UNIX.mode=0644;UNIX.owner=1000; wel come.msg")]
-        [TestCase("create=20120825130005;lang=en;media-type=TEXT;charset=UTF-8;modify=20030225143801;perm=acdeflmprw;size=3243243332343503;type=dir;unique=12U24470006;UNIX.group=100;UNIX.mode=0644;UNIX.owner=1000; wel come.msg")]
-        public void TestMlsxItem(string line)
+        [TestCase("Type=file;Size=1830;Modify=19940916055648;Perm=r; hatch.c", "hatch.c" )]
+        [TestCase("modify=20120822211414;perm=adfr;size=2101;type=file;unique=16UF3F5;UNIX.group=49440;UNIX.mode=0744;UNIX.owner=49440; iphone_settings_icon.jpg", "iphone_settings_icon.jpg")]
+        [TestCase("modify=20030225143801;perm=adfr;size=503;type=file;unique=12U24470006;UNIX.group=0;UNIX.mode=0644;UNIX.owner=0; welcome.msg", "welcome.msg")]
+        [TestCase("type=dir;modify=20120825130005; /Test", "/Test")]
+        [TestCase("create=20120825130005;lang=en;media-type=TEXT;charset=UTF-8;modify=20030225143801;perm=acdeflmprw;size=3243243332343503;type=file;unique=12U24470006;UNIX.group=100;UNIX.mode=0644;UNIX.owner=1000; wel come.msg", "wel come.msg")]
+        [TestCase("create=20120825130005;lang=fr;media-type=TEXT;charset=UTF-7;modify=20030225143801;perm=acdeflmprw;size=3243243332343503;type=pdir;unique=12U24470006;UNIX.group=100;UNIX.mode=0644;UNIX.owner=1000; wel come.msg", "wel come.msg")]
+        [TestCase("create=20120825130005;lang=sp;media-type=TEXT;charset=UTF-8;modify=20030225143801;perm=acdeflmprw;size=3243243332343503;type=cdir;unique=12U24470006;UNIX.group=100;UNIX.mode=0644;UNIX.owner=1000; wel come.msg", "wel come.msg")]
+        [TestCase("create=20120825130005;lang=en;media-type=TEXT;charset=UTF-8;modify=20030225143801;perm=acdeflmprw;size=3243243332343503;type=dir;unique=12U24470006;UNIX.group=100;UNIX.mode=0644;UNIX.owner=1000; wel come.msg", "wel come.msg")]
+        [TestCase("type=file;modify=20180302161100;size=523843732;UNIX.mode=0777;UNIX.owner=testuser;UNIX.group=users; The Rob Schneider Chronicles;S11E24.mp4", "The Rob Schneider Chronicles;S11E24.mp4")]
+        [TestCase("type=file;perm=-rw-r--r--;modify=20171222063634;size=16471; mail-editor.png", "mail-editor.png")]
+        public void TestMlsxItem(string line, string filename)
         {
             FtpsMlsxItemParser p = new FtpsMlsxItemParser();
-            p.ParseLine(line);
+            FtpsItem item = p.ParseLine(line);
+            Assert.AreEqual( filename, item.Name );
             Console.WriteLine(p.ToString());
         }
 

--- a/Starksoft.Aspen/Ftps/FtpsItemCollection.cs
+++ b/Starksoft.Aspen/Ftps/FtpsItemCollection.cs
@@ -161,8 +161,8 @@ namespace Starksoft.Aspen.Ftps
                     row[COL_MLSX_LANGUAGE] = mitem.Language == null ? String.Empty : mitem.Language;
                     row[COL_MLSX_MEDIA_TYPE] = mitem.MediaType == null ? String.Empty : mitem.MediaType;
                     row[COL_MLSX_CHARACTER_SET] = mitem.CharacterSet == null ? String.Empty : mitem.CharacterSet;
-                    row[COL_MLSX_GROUP] = mitem.Group == null ? 0 : mitem.Group;
-                    row[COL_MLSX_OWNER] = mitem.Owner == null ? 0 : mitem.Owner;
+                    row[COL_MLSX_GROUP] = mitem.Group == null ? "" : mitem.Group;
+                    row[COL_MLSX_OWNER] = mitem.Owner == null ? "" : mitem.Owner;
                 }
 
                 dataTbl.Rows.Add(row);
@@ -193,8 +193,8 @@ namespace Starksoft.Aspen.Ftps
             dataTbl.Columns.Add(new DataColumn(COL_MLSX_LANGUAGE, typeof(String)));
             dataTbl.Columns.Add(new DataColumn(COL_MLSX_MEDIA_TYPE, typeof(String)));
             dataTbl.Columns.Add(new DataColumn(COL_MLSX_CHARACTER_SET, typeof(String)));
-            dataTbl.Columns.Add(new DataColumn(COL_MLSX_GROUP, typeof(Int32)));
-            dataTbl.Columns.Add(new DataColumn(COL_MLSX_OWNER, typeof(Int32)));
+            dataTbl.Columns.Add(new DataColumn(COL_MLSX_GROUP, typeof(String)));
+            dataTbl.Columns.Add(new DataColumn(COL_MLSX_OWNER, typeof(String)));
         }
 
         /// <summary>

--- a/Starksoft.Aspen/Ftps/FtpsMlsxItem.cs
+++ b/Starksoft.Aspen/Ftps/FtpsMlsxItem.cs
@@ -150,8 +150,8 @@ namespace Starksoft.Aspen.Ftps
         private string _characterSet;   // charset=
 
         // UNIX specific MLSx object facts
-        private Int32? _group;      // UNIX.group=
-        private Int32? _owner;      // UNIX.owner=
+        private string _group;      // UNIX.group=
+        private string _owner;      // UNIX.owner=
 
         /// <summary>
         /// Default constructor.
@@ -191,8 +191,8 @@ namespace Starksoft.Aspen.Ftps
                        string language,
                        string mediaType,
                        string characterSet,
-                       Int32? group,
-                       Int32? owner
+                       string group,
+                       string owner
                      ) : base(name, modified, size, itemType, attributes, mode, String.Empty, rawText)
         {
             _created = created;
@@ -268,7 +268,7 @@ namespace Starksoft.Aspen.Ftps
         /// UNIX.* facts.  This value is a nullable field and will be null if no
         /// fact name was found.
         /// </remarks>
-        public Int32? Group
+        public string Group
         {
             get { return _group; }
         }
@@ -282,7 +282,7 @@ namespace Starksoft.Aspen.Ftps
         /// UNIX.* facts.  This value is a nullable field and will be null if no
         /// fact name was found.
         /// </remarks>
-        public Int32? Owner
+        public string Owner
         {
             get { return _owner; }
         }

--- a/Starksoft.Aspen/Proxy/HttpProxyClient.cs
+++ b/Starksoft.Aspen/Proxy/HttpProxyClient.cs
@@ -337,7 +337,7 @@ namespace Starksoft.Aspen.Proxy
                 //HOST starksoft.com:443<CR><LF>
                 //[... other HTTP header lines ending with <CR><LF> if required]>
                 //<CR><LF>    // Last Empty Line
-                connectCmd = String.Format(CultureInfo.InvariantCulture, HTTP_PROXY_CONNECT_CMD + "\r\n", host, port.ToString(CultureInfo.InvariantCulture));
+                connectCmd = String.Format(CultureInfo.InvariantCulture, HTTP_PROXY_CONNECT_CMD, host, port.ToString(CultureInfo.InvariantCulture));
             }
             return connectCmd;
         }


### PR DESCRIPTION
We've found a few problems with various FTP servers.

1. Windows allows semicolons in filenames which the parser did not expect.
2. The CRLF after the CONNECT command for an HTTP proxy was unnecessary. A proxy we were using would reject the connection because of it.
3. Some servers would send the actual names, not the IDs for UNIX.owner and UNIX.group facts.
4. Wing FTP Server sends POSIX-style permissions that are not compliant with RFC 3659.
