### PR TITLE
Update Gpg.cs

### DIFF
--- a/Starksoft.Aspen/GnuPG/Gpg.cs
+++ b/Starksoft.Aspen/GnuPG/Gpg.cs
@@ -560,6 +560,9 @@ namespace Starksoft.Aspen.GnuPG
             if (!String.IsNullOrEmpty (_homePath))
                 options.Append(String.Format(CultureInfo.InvariantCulture, "--homedir \"{0}\" ", _homePath));
             
+            // this will prevent prompting for passphrase in newer version of Gpg
+            options.Append("--pinentry-mode loopback ");
+            
             //  tell gpg to read the passphrase from the standard input so we can automate providing it
             options.Append("--passphrase-fd 0 ");
             


### PR DESCRIPTION
In newer version of Gpg, it continuously prompts for passphrase and to avoid that we need to append this argument "--pinentry-mode loopback"