### PR TITLE
Handle repeated 211- prefix in lines of FEAT reply

### DIFF
--- a/Starksoft.Aspen/Ftps/FtpsFeatureCollection.cs
+++ b/Starksoft.Aspen/Ftps/FtpsFeatureCollection.cs
@@ -311,6 +311,7 @@ namespace Starksoft.Aspen.Ftps
                 fl = lines[i];
                 if (fl.Length < 2)
                     throw new FtpsFeatureException("not a properly formatted feature line");
+                fl = fl.Replace(preamble, " ");
                 if (fl.Substring(0, 1) != " ")
                     break;
                 string[] v = SplitFeature(fl);


### PR DESCRIPTION
I found a compatibility issue when testing against a linux server running ProFTPd 1.3.6. Specifically the latest 1.3.6b, but based on their change logs it might apply to the entire 1.3.6 series or older?
What I did was make a fresh install of Ubuntu, then 'apt-get install proftpd' and then I configured it with an account and enabled mod_tls and forced TLS session resumption. (I'll talk more about that later, it's not related to this PR)

Attempting to use that test FTP I set up threw the exception 'epilogue not found while parsing feature list' because it couldn't parse the feature list. What's happening is the server is repeating 211- for every single line instead of a space in front of subsequent lines like the code expects. Example is below. This fix just reformats the line into what FtpsFeatureCollection.Parse() is expecting to see and then the connection appears to proceed correctly. Sample below:

> 
> 211-Features:
> 211-AUTH TLS
> 211-CCC
> 211-CLNT
> 211-EPRT
> 211-EPSV
> 211-HOST
> 211-LANG en-US.UTF-8*;en-US
> 211-MDTM
> 211-MFF modify;UNIX.group;UNIX.mode;
> 211-MFMT
> 211-MLST modify*;perm*;size*;type*;unique*;UNIX.group*;UNIX.groupname*;UNIX.mode*;UNIX.owner*;UNIX.ownername*;
> 211-PBSZ
> 211-PROT
> 211-REST STREAM
> 211-SITE COPY
> 211-SITE MKDIR
> 211-SITE RMDIR
> 211-SITE SYMLINK
> 211-SITE UTIME
> 211-SIZE
> 211-SSCN
> 211-TVFS
> 211-UTF8
> 211 End
> 

For a little background, I ran into this while I was looking into some problems caused by the [October Windows updates ](https://support.microsoft.com/en-us/help/4528489/transport-layer-security-tls-connections-might-fail-or-timeout-when-co). Those problems are out of your control since you use SslStream, but I had a server we couldn't connect to and the owner of the server insisted that it was up to date. What I was seeing from Wireshark was the SSL handshake was not advertising Extended Master Secret, which the October 2019 Windows patches require to use session resumption. I confirmed that the latest ProFTPd with latest OpenSSL does advertise extended master secret and session resumption via your library does work, so Microsoft's suggestion of "If you encounter this issue, you will need to contact the manufacturer or service provider for updates that comply with RFC standards." is valid. Just thought it's worth mentioning in case someone ever opens an issue due to compatibility problems caused connecting to TLS FTP servers when Windows is patched.