### PR TITLE
Fix problem with replacing any non-ascii chars to char with code 65533.

### DIFF
--- a/Starksoft.Aspen/GnuPG/Gpg.cs
+++ b/Starksoft.Aspen/GnuPG/Gpg.cs
@@ -795,7 +795,7 @@ namespace Starksoft.Aspen.GnuPG
                 //  if the process exit code is not 0 then read the error text from the gpg.exe process 
                 if (_proc.ExitCode != 0 && !_ignoreErrors)
                 {
-                    StreamReader rerror = new StreamReader(_errorStream);
+                    StreamReader rerror = new StreamReader(_errorStream, _proc.StandardError.CurrentEncoding);
                     _errorStream.Position = 0;
                     gpgErrorText = rerror.ReadToEnd();
                 }


### PR DESCRIPTION
Hi. I fixed problem with exception. For example my windows console is used 852 codepage and for non-ascii chars exception looks like this:
e.Message.ToCharArray()
{char[119]}
    [0]: 103 'g'
    [1]: 112 'p'
    [2]: 103 'g'
    [3]: 58 ':'
    [4]: 32 ' '
    [5]: 69 'E'
    [6]: 65 'A'
    [7]: 52 '4'
    [8]: 55 '7'
    [9]: 56 '8'
    [10]: 69 'E'
    [11]: 65 'A'
    [12]: 55 '7'
    [13]: 58 ':'
    [14]: 32 ' '
    [15]: 112 'p'
    [16]: 111 'o'
    [17]: 109 'm'
    [18]: 105 'i'
    [19]: 110 'n'
    [20]: 105 'i'
    [21]: 65533 '�'
    [22]: 116 't'
    [23]: 121 'y'

To fix it one parameter to stream reader for exception must be added. It always try to read stream with the same encoding like standard error stream, not .net default one. Now string is correct or convertable (because not all non-ascii chars are replaced by  65533 '�' ).

This is only one line fix.